### PR TITLE
Auto add the parent directory for an open file to project_data() when it is contained in the folder list

### DIFF
--- a/Side Bar Folders.sublime-settings
+++ b/Side Bar Folders.sublime-settings
@@ -16,5 +16,8 @@
     "label_replace_regexp": "^[a-z]:\\((www|projects)\\)?",
 
     //Unix style? replace every \ with /
-    "label_unix_style": true
+    "label_unix_style": true,
+
+    //auto load folder for opened file when it is contained in the folder list
+    "auto_load_folder_for_opened_file": true
 }

--- a/SideBarFolders.py
+++ b/SideBarFolders.py
@@ -75,6 +75,17 @@ def is_sidebar_open():
 			return True # print('sidebar is open')
 	return True # by default assume is open if no view is opened
 
+def is_subdir(path, directory):
+    path = os.path.realpath(path)
+    directory = os.path.realpath(directory)
+
+    relative = os.path.relpath(path, directory)
+
+    if relative.startswith(os.pardir):
+        return False
+    else:
+        return True
+
 class Menu(object):
 	@staticmethod
 	def prepare_menu():
@@ -285,6 +296,26 @@ class side_bar_folders_sidebar_clear(sublime_plugin.WindowCommand):
 class side_bar_folders_listener(sublime_plugin.EventListener):
 	def on_activated(self, view):
 		pref.save_folders()
+
+class side_bar_folders_auto_add_folder_listener(sublime_plugin.EventListener):
+    def on_activated(self, view):
+        f = view.file_name()
+        if not f or view.settings().has('side_bar_folders_auto_load_folder'):
+            return
+        path = os.path.dirname(f)
+        view.settings().set('side_bar_folders_auto_load_folder', 1)
+        if s.get('auto_load_folder_for_opened_file') and path and os.path.exists(path):
+            for folder in pref.folders:
+                if is_subdir(path, folder['path']):
+                    project_data = view.window().project_data()
+                    if not project_data or "folders" not in project_data:
+                        project_data = {'folders': [{'path': path, 'follow_symlinks': True}]}
+                    else:
+                        project_data["folders"].append({'path': path, 'follow_symlinks': True})
+
+                    view.window().set_project_data(project_data)
+                    break
+            sublime.set_timeout(lambda: view.window().run_command('reveal_in_side_bar'), 100)
 
 class side_bar_folders_swap(sublime_plugin.WindowCommand):
 	def run(self):


### PR DESCRIPTION
I have made two changes.
1. remove the confusion of the usage of `Pref` by using instance variable `pref`
2. Auto add the parent directory for an open file to project_data() when it is contained in the folder list.
