### PR TITLE
fix a bug when project_data is none

### DIFF
--- a/SideBarFolders.py
+++ b/SideBarFolders.py
@@ -308,6 +308,8 @@ class side_bar_folders_auto_add_folder_listener(sublime_plugin.EventListener):
 		path = os.path.dirname(f)
 		view.settings().set('side_bar_folders_auto_load_folder', 1)
 		project_data = view.window().project_data()
+		if project_data is None:
+			project_data = {}
 		if any([is_subdir(path, folder['path']) for folder in project_data]):
 			return
 		if s.get('auto_load_folder_for_opened_file') and path and os.path.exists(path):


### PR DESCRIPTION
Per the discussion [here](https://github.com/SublimeText/SideBarFolders/commit/b18516f1c6f97e01120ab32eb6a33765328cfdc8#sidebarfolders-py-P5)
